### PR TITLE
Add timestamps to logs

### DIFF
--- a/api_project/settings.py
+++ b/api_project/settings.py
@@ -274,9 +274,15 @@ SPECTACULAR_SETTINGS = {
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    'formatters': {
+        'timestamped_named': {
+            'format': '%(asctime)s %(name)s %(levelname)s: %(message)s',
+        },
+    },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
+            'formatter': 'timestamped_named',
         },
     },
     "root": {


### PR DESCRIPTION
Currently logged messages have no timestamp or source module. This should make it easier to understand the logging.