### PR TITLE
Added cx_Oracle SessionPool to Facta API requests

### DIFF
--- a/facta_api/hel_facta/abstract/facta.py
+++ b/facta_api/hel_facta/abstract/facta.py
@@ -1,5 +1,5 @@
-import cx_Oracle
 import logging
+from .facta_session_pool import session_pool
 
 log = logging.getLogger(__name__)
 
@@ -7,26 +7,19 @@ log = logging.getLogger(__name__)
 class Facta:
     table_name = None
     mocked = False
+    conn = None
 
-    def __init__(self, user=None, password=None, host=None, mock_data_dir=None):
+    def __init__(self, mock_data_dir=None):
         if not self.table_name:
             raise RuntimeError("Need to inherit this class.")
 
         if mock_data_dir:
             self.mocked = True
             self._mock_login(mock_data_dir)
-        elif user and password and host:
-            self.login(user, password, host)
+        elif session_pool:
+            self.conn = session_pool.acquire()
         else:
             raise ValueError("Oracle DB connection or mocking needed!")
-
-    def login(self, user, password, host):
-        log.debug(
-            "Oracle client version: %s"
-            % ".".join(tuple(map(str, cx_Oracle.clientversion())))
-        )
-        self.conn = cx_Oracle.connect(user, password, host)
-        log.debug("Connected to Oracle server version: %s" % self.conn.version)
 
     def _mock_login(self, mock_data_dir):
         from .mock_oracle import MockOracleConnection

--- a/facta_api/hel_facta/abstract/facta_session_pool.py
+++ b/facta_api/hel_facta/abstract/facta_session_pool.py
@@ -1,0 +1,25 @@
+import cx_Oracle
+import logging
+
+from common_auth.models.ext_auth_cred import ExtAuthCred
+from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
+
+session_pool = None
+
+
+try:
+    facta_creds = ExtAuthCred.objects.get(system='Facta')
+    if facta_creds:
+        session_pool = cx_Oracle.SessionPool(
+            facta_creds.username,
+            facta_creds.credential,
+            facta_creds.host_spec,
+            min=10,
+            max=10,
+            increment=0,
+            getmode=cx_Oracle.SPOOL_ATTRVAL_WAIT,
+        )
+except ObjectDoesNotExist:
+    logging.error("Failed to initialize cx_Oracle SessionPool -- No ExtAuthCred entry found for Facta")
+except MultipleObjectsReturned:
+    logging.error("Failed to initialize cx_Oracle SessionPool -- Multiple ExAuthCred entries found for Facta")

--- a/facta_api/views/v1/kiinteisto_all.py
+++ b/facta_api/views/v1/kiinteisto_all.py
@@ -29,8 +29,7 @@ class API(KiinteistoAPI, RakennusAPI):
             return HttpResponseBadRequest("Need valid kiinteistotunnus!")
         if not request.auth:
             return HttpResponse(status=401)
-        self.facta_creds = request.auth.access_facta
-        if not self.facta_creds:
+        if not self.request.auth.access_facta:
             return HttpResponseForbidden("No access!")
 
         owners, occupants = self.get_kiinteisto(ktunnus_to_use)
@@ -98,11 +97,7 @@ class API(KiinteistoAPI, RakennusAPI):
         if mock_dir:
             f_ko = hel_facta.KiinteistonOmistajat(mock_data_dir=mock_dir)
         else:
-            f_ko = hel_facta.KiinteistonOmistajat(
-                user=self.facta_creds.username,
-                password=self.facta_creds.credential,
-                host=self.facta_creds.host_spec,
-            )
+            f_ko = hel_facta.KiinteistonOmistajat()
         rows = f_ko.get_by_kiinteistotunnus(ktunnus)
         # if not rows:
         #    return HttpResponseNotFound()
@@ -135,11 +130,8 @@ class API(KiinteistoAPI, RakennusAPI):
         if mock_dir:
             f_kh = hel_facta.KiinteistonHaltijat(mock_data_dir=mock_dir)
         else:
-            f_kh = hel_facta.KiinteistonHaltijat(
-                user=self.facta_creds.username,
-                password=self.facta_creds.credential,
-                host=self.facta_creds.host_spec,
-            )
+            f_kh = hel_facta.KiinteistonHaltijat()
+
         rows = f_kh.get_by_kiinteistotunnus(ktunnus)
 
         # Process result:
@@ -160,11 +152,7 @@ class API(KiinteistoAPI, RakennusAPI):
         if mock_dir:
             f_ko = hel_facta.RakennuksenOmistajat(mock_data_dir=mock_dir)
         else:
-            f_ko = hel_facta.RakennuksenOmistajat(
-                user=self.facta_creds.username,
-                password=self.facta_creds.credential,
-                host=self.facta_creds.host_spec,
-            )
+            f_ko = hel_facta.RakennuksenOmistajat()
         rows = f_ko.get_by_kiinteistotunnus(ktunnus)
 
         owner_rows = []

--- a/facta_api/views/v1/kiinteiston_haltijat.py
+++ b/facta_api/views/v1/kiinteiston_haltijat.py
@@ -27,8 +27,7 @@ class API(KiinteistoAPI):
             return HttpResponseBadRequest("Need valid kiinteistotunnus!")
         if not request.auth:
             return HttpResponse(status=401)
-        facta_creds = request.auth.access_facta
-        if not facta_creds:
+        if not request.auth.access_facta:
             return HttpResponseForbidden("No access!")
 
         # Confirmed access to Facta Oracle SQL.
@@ -38,11 +37,7 @@ class API(KiinteistoAPI):
         if mock_dir:
             f_kh = hel_facta.KiinteistonHaltijat(mock_data_dir=mock_dir)
         else:
-            f_kh = hel_facta.KiinteistonHaltijat(
-                user=facta_creds.username,
-                password=facta_creds.credential,
-                host=facta_creds.host_spec,
-            )
+            f_kh = hel_facta.KiinteistonHaltijat()
         rows = f_kh.get_by_kiinteistotunnus(ktunnus_to_use)
         if not rows:
             return HttpResponseNotFound()

--- a/facta_api/views/v1/kiinteiston_omistajat.py
+++ b/facta_api/views/v1/kiinteiston_omistajat.py
@@ -29,8 +29,7 @@ class API(KiinteistoAPI):
             return HttpResponseBadRequest("Need valid kiinteistotunnus!")
         if not request.auth:
             return HttpResponse(status=401)
-        facta_creds = request.auth.access_facta
-        if not facta_creds:
+        if not request.auth.access_facta:
             return HttpResponseForbidden("No access!")
 
         # Confirmed access to Facta Oracle SQL.
@@ -40,11 +39,7 @@ class API(KiinteistoAPI):
         if mock_dir:
             f_ko = hel_facta.KiinteistonOmistajat(mock_data_dir=mock_dir)
         else:
-            f_ko = hel_facta.KiinteistonOmistajat(
-                user=facta_creds.username,
-                password=facta_creds.credential,
-                host=facta_creds.host_spec,
-            )
+            f_ko = hel_facta.KiinteistonOmistajat()
         rows = f_ko.get_by_kiinteistotunnus(ktunnus_to_use)
         if not rows:
             return HttpResponseNotFound()

--- a/facta_api/views/v1/rakennuksen_omistajat.py
+++ b/facta_api/views/v1/rakennuksen_omistajat.py
@@ -30,19 +30,14 @@ class API(KiinteistoAPI, RakennusAPI):
             return HttpResponseBadRequest("Need valid kiinteistotunnus!")
         if not request.auth:
             return HttpResponse(status=401)
-        facta_creds = request.auth.access_facta
-        if not facta_creds:
+        if not request.auth.access_facta:
             return HttpResponseForbidden("No access!")
 
         mock_dir = settings.FACTA_DB_MOCK_DATA_DIR
         if mock_dir:
             f_ko = hel_facta.RakennuksenOmistajat(mock_data_dir=mock_dir)
         else:
-            f_ko = hel_facta.RakennuksenOmistajat(
-                user=facta_creds.username,
-                password=facta_creds.credential,
-                host=facta_creds.host_spec,
-            )
+            f_ko = hel_facta.RakennuksenOmistajat()
         rows = f_ko.get_by_kiinteistotunnus(ktunnus_to_use)
         if not rows:
             return HttpResponseNotFound()


### PR DESCRIPTION
This is to remove the need to create a new database connection every time sql query is made.

Initialisation of the session pool happens when Kaavoitus-API starts. During initialisation it is expected that ext_auth_cred entry for Facta exists in database.